### PR TITLE
Check housekeepingMenuActive instead of closeApplicationEnabled

### DIFF
--- a/data/unified_diff.patch
+++ b/data/unified_diff.patch
@@ -25,7 +25,7 @@
  
      property real contentY
 -    statusOffset: Math.min(contentY, statusBar.height + Theme.paddingMedium)
-+    statusOffset: (desktop != null && desktop.switcher.closeApplicationEnabled) ? Math.min(contentY, statusBar.height + Theme.paddingMedium) : 0
++    statusOffset: (desktop != null && desktop.switcher.housekeepingMenuActive) ? Math.min(contentY, statusBar.height + Theme.paddingMedium) : 0
  
      Item {
          id: content


### PR DESCRIPTION
Thanks for this cool patch.

This change makes it play together nicely with a [lockscreen-pulley-at-home patch](https://openrepos.net/content/cornerman/patch-lockscreen-pulley-home), so that the statusbar is placed beneath the pulldown menu. Otherwise, the behaviour stays the same.
